### PR TITLE
Investigate ollama setup script discrepancy

### DIFF
--- a/new_text/USE_LOCAL_SKYWORK.md
+++ b/new_text/USE_LOCAL_SKYWORK.md
@@ -1,0 +1,87 @@
+# 使用本地 Skywork-R1V3-38B 模型
+
+既然您本地已经有 Skywork-R1V3-38B 模型，您需要修改以下配置：
+
+## 1. 修改 config.json
+
+将以下部分进行修改：
+
+### API配置部分
+```json
+"api": {
+    "ark_url": "http://localhost:8080/v1",  // 改为localhost
+    "use_local_models": true,
+    "local_model_priority": ["vllm", "transformers", "ollama"]  // vllm优先
+}
+```
+
+### vLLM配置部分
+```json
+"vllm": {
+    "enabled": true,  // 改为true
+    "base_url": "http://localhost:8080",  // 改为8080端口
+    "model_name": "/mnt/storage/models/Skywork/Skywork-R1V3-38B",  // 使用本地路径
+    "timeout": 600
+}
+```
+
+### Transformers配置部分
+```json
+"transformers": {
+    "enabled": true,  // 改为true
+    "model_name": "/mnt/storage/models/Skywork/Skywork-R1V3-38B",  // 使用本地路径
+    "device": "auto",
+    "torch_dtype": "auto",
+    "load_in_4bit": false,
+    "load_in_8bit": true  // 使用8位量化减少显存
+}
+```
+
+## 2. 使用方法
+
+### 方案A：使用vLLM（推荐）
+
+1. 安装vLLM：
+```bash
+pip install vllm
+```
+
+2. 启动vLLM服务：
+```bash
+python -m vllm.entrypoints.openai.api_server \
+    --model /mnt/storage/models/Skywork/Skywork-R1V3-38B \
+    --host 0.0.0.0 \
+    --port 8080 \
+    --max-model-len 4096 \
+    --gpu-memory-utilization 0.9
+```
+
+3. 运行程序：
+```bash
+python run_pipeline.py --input_path data/texts --use_local_models
+```
+
+### 方案B：使用Transformers
+
+1. 安装依赖：
+```bash
+pip install transformers torch accelerate bitsandbytes
+```
+
+2. 直接运行：
+```bash
+python run_pipeline.py --input_path data/texts --use_local_models --model_type transformers
+```
+
+## 3. 为什么还需要setup_ollama.sh？
+
+- setup_ollama.sh 是为了提供一个轻量级的备用方案
+- 当Skywork模型不可用或显存不足时，可以使用Ollama运行较小的模型
+- 这是一个多层次的容错设计，确保系统的高可用性
+
+## 4. 注意事项
+
+- Skywork-R1V3-38B 需要大量GPU显存（建议40GB+）
+- 如果显存不足，可以使用8位量化
+- vLLM提供更好的推理性能
+- 确保端口8080没有被其他服务占用

--- a/new_text/USE_LOCAL_SKYWORK.txt
+++ b/new_text/USE_LOCAL_SKYWORK.txt
@@ -1,0 +1,23 @@
+# 使用本地 Skywork-R1V3-38B 模型配置说明
+
+## 需要修改的地方
+
+1. 在 config.json 中修改 API 配置：
+   - ark_url: 改为 http://localhost:8080/v1
+   - use_local_models: 确保为 true
+   - local_model_priority: 改为 ["vllm", "transformers", "ollama"]
+
+2. 在 config.json 中修改 vLLM 配置：
+   - enabled: 改为 true
+   - base_url: 改为 http://localhost:8080
+   - model_name: 改为 /mnt/storage/models/Skywork/Skywork-R1V3-38B
+
+3. 使用 vLLM 启动本地模型服务：
+   python -m vllm.entrypoints.openai.api_server --model /mnt/storage/models/Skywork/Skywork-R1V3-38B --host 0.0.0.0 --port 8080
+
+4. 运行程序：
+   python run_pipeline.py --use_local_models
+
+为什么需要 setup_ollama.sh：
+- 提供备用方案，当主模型不可用时使用
+- 多层次容错设计，确保系统高可用性

--- a/new_text/setup_skywork_local.sh
+++ b/new_text/setup_skywork_local.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+echo "配置本地 Skywork-R1V3-38B 模型..."
+
+# 检查模型路径是否存在
+MODEL_PATH="/mnt/storage/models/Skywork/Skywork-R1V3-38B"
+if [ ! -d "$MODEL_PATH" ]; then
+    echo "错误：模型路径不存在: $MODEL_PATH"
+    exit 1
+fi
+
+echo "找到模型路径: $MODEL_PATH"
+
+# 方案1：使用 vLLM 启动模型服务（推荐用于生产环境）
+echo ""
+echo "=== 方案1：使用 vLLM ==="
+echo "安装 vLLM（需要 GPU）："
+echo "pip install vllm"
+echo ""
+echo "启动 vLLM 服务："
+echo "python -m vllm.entrypoints.openai.api_server \\"
+echo "    --model $MODEL_PATH \\"
+echo "    --host 0.0.0.0 \\"
+echo "    --port 8080 \\"
+echo "    --max-model-len 4096 \\"
+echo "    --gpu-memory-utilization 0.9"
+
+# 方案2：使用 transformers 直接加载（适合开发测试）
+echo ""
+echo "=== 方案2：使用 Transformers ==="
+echo "安装依赖："
+echo "pip install transformers torch accelerate"
+echo ""
+echo "配置已更新，可以直接使用 transformers 模式"
+
+# 更新配置文件
+echo ""
+echo "=== 更新配置文件 ==="
+cat > skywork_config_update.json << 'EOF'
+{
+  "api": {
+    "ark_url": "http://localhost:8080/v1",
+    "use_local_models": true,
+    "local_model_priority": ["vllm", "transformers", "ollama"]
+  },
+  "models": {
+    "default_model": "/mnt/storage/models/Skywork/Skywork-R1V3-38B",
+    "local_models": {
+      "vllm": {
+        "enabled": true,
+        "base_url": "http://localhost:8080",
+        "model_name": "/mnt/storage/models/Skywork/Skywork-R1V3-38B",
+        "timeout": 600
+      },
+      "transformers": {
+        "enabled": true,
+        "model_name": "/mnt/storage/models/Skywork/Skywork-R1V3-38B",
+        "device": "auto",
+        "torch_dtype": "auto",
+        "load_in_4bit": false,
+        "load_in_8bit": true
+      }
+    }
+  }
+}
+EOF
+
+echo "配置更新已保存到 skywork_config_update.json"
+echo ""
+echo "=== 使用说明 ==="
+echo "1. 使用 vLLM（推荐）："
+echo "   - 先启动 vLLM 服务（见上面的命令）"
+echo "   - 然后运行：python run_pipeline.py --use_local_models --model_type vllm"
+echo ""
+echo "2. 使用 Transformers（开发测试）："
+echo "   - 直接运行：python run_pipeline.py --use_local_models --model_type transformers"
+echo ""
+echo "3. 更新现有配置："
+echo "   - 将 skywork_config_update.json 的内容合并到 config.json"


### PR DESCRIPTION
Add documentation and a setup script to enable direct use of a local Skywork-R1V3-38B model.

This provides users with a high-performance local option for the Skywork model, complementing the existing Ollama setup which serves as a fallback for smaller models or when the primary API is unavailable.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f6aff19-a6d5-4c49-814c-d21617ac60b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6f6aff19-a6d5-4c49-814c-d21617ac60b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

